### PR TITLE
perf(int_extension): rewrite `isPrime` method with more performant iteration

### DIFF
--- a/lib/utils/int_extension.dart
+++ b/lib/utils/int_extension.dart
@@ -1,16 +1,27 @@
-import 'dart:math';
+final Map<int, bool> primes = {
+  1: false,
+  2: true,
+};
 
 extension IntExtension on int {
   bool get isPrime {
-    if (this <= 1) return false;
-    if (this == 2) return true;
-    if (isEven) return false;
+    final cachedPrime = primes[this];
+    if (cachedPrime != null) return cachedPrime;
 
-    final maxDivisor = sqrt(this).floor();
-    for (var i = 3; i <= maxDivisor; i += 2) {
-      if (this % i == 0) return false;
+    if (this <= 1 || isEven) return primes[this] = false;
+
+    for (var i = 3;
+        // Do not excede the square root of num.
+        i * i <= this;
+        // All prime numbers are 1 or 5 modulo 6.
+        // Since we start with 3, this will do:
+        // 3 -> 5 -> 7 -> 11 ... +2 -> +4 -> +2 -> +4 ...
+        i = i % 6 == 1 ? i + 4 : i + 2) {
+      if (this % i == 0) {
+        return primes[this] = false;
+      }
     }
 
-    return true;
+    return primes[this] = true;
   }
 }

--- a/lib/utils/int_extension.dart
+++ b/lib/utils/int_extension.dart
@@ -7,7 +7,12 @@ extension IntExtension on int {
     if (isEven) return false;
 
     final maxDivisor = sqrt(this).floor();
-    for (var i = 3; i <= maxDivisor; i = i % 6 == 1 ? i + 4 : i + 2) {
+    for (var i = 3;
+        i <= maxDivisor;
+        // All prime numbers are 1 or 5 modulo 6.
+        // Since we start with 3, this will do:
+        // 3 -> 5 -> 7 -> 11 ... +2 -> +4 -> +2 -> +4 ...
+        i = i % 6 == 1 ? i + 4 : i + 2) {
       if (this % i == 0) return false;
     }
 

--- a/lib/utils/int_extension.dart
+++ b/lib/utils/int_extension.dart
@@ -1,27 +1,16 @@
-final Map<int, bool> primes = {
-  1: false,
-  2: true,
-};
+import 'dart:math';
 
 extension IntExtension on int {
   bool get isPrime {
-    final cachedPrime = primes[this];
-    if (cachedPrime != null) return cachedPrime;
+    if (this <= 1) return false;
+    if (this == 2) return true;
+    if (isEven) return false;
 
-    if (this <= 1 || isEven) return primes[this] = false;
-
-    for (var i = 3;
-        // Do not excede the square root of num.
-        i * i <= this;
-        // All prime numbers are 1 or 5 modulo 6.
-        // Since we start with 3, this will do:
-        // 3 -> 5 -> 7 -> 11 ... +2 -> +4 -> +2 -> +4 ...
-        i = i % 6 == 1 ? i + 4 : i + 2) {
-      if (this % i == 0) {
-        return primes[this] = false;
-      }
+    final maxDivisor = sqrt(this).floor();
+    for (var i = 3; i <= maxDivisor; i = i % 6 == 1 ? i + 4 : i + 2) {
+      if (this % i == 0) return false;
     }
 
-    return primes[this] = true;
+    return true;
   }
 }

--- a/test/utils/int_extension_test.dart
+++ b/test/utils/int_extension_test.dart
@@ -11,7 +11,7 @@ void main() {
       });
 
       test('should return false if this int is not prime', () {
-        for (final n in const [-11, -1, 0, 1, 110, 500]) {
+        for (final n in const [-11, -1, 0, 1, 49, 110, 511]) {
           expect(n.isPrime, isFalse);
         }
       });


### PR DESCRIPTION
## Benchmark

Running the following benchmark, we get these results:

```sh
 isPrime
  ✓ Square root (36 ms)
  ✓ Square root leap (34 ms)
  ✓ Squared (37 ms)
  ✓ Cached (119 ms)

Benchmark suites: 1 passed, 1 total
Benchmarks:       4 passed, 4 total
Time:             9 s
```

<details><summary>Benchmark code</summary>

```dart
import 'dart:math';

import 'package:benchmark/benchmark.dart';

final Map<int, bool> primes = {
  1: false,
  2: true,
};

extension IntExtension on int {
  bool get isPrimeSqrt {
    if (this <= 1) return false;
    if (this == 2) return true;
    if (isEven) return false;

    final maxDivisor = sqrt(this).floor();
    for (var i = 3; i <= maxDivisor; i += 2) {
      if (this % i == 0) return false;
    }

    return true;
  }

  bool get isPrimeSqrtLeap {
    if (this <= 1) return false;
    if (this == 2) return true;
    if (isEven) return false;

    final maxDivisor = sqrt(this).floor();
    for (var i = 3; i <= maxDivisor; i = i % 6 == 1 ? i + 4 : i + 2) {
      if (this % i == 0) return false;
    }

    return true;
  }

  bool get isPrimeSq {
    if (this <= 1) return false;
    if (this == 2) return true;
    if (isEven) return false;

    for (var i = 3; i * i <= this; i += 2) {
      if (this % i == 0) return false;
    }

    return true;
  }

  bool get isPrimeCached {
    final cachedPrime = primes[this];
    if (cachedPrime != null) return cachedPrime;

    if (this <= 1 || isEven) return primes[this] = false;

    final maxDivisor = sqrt(this).floor();
    for (var i = 3; i <= maxDivisor; i = i % 6 == 1 ? i + 4 : i + 2) {
      if (this % i == 0) {
        return primes[this] = false;
      }
    }

    return primes[this] = true;
  }
}

void main() {
  late List<int>? list;

  setUp(() {
    list = List.generate(1000, (i) => i);
  });

  tearDown(() {
    list = null;
  });

  group('isPrime', () {
    benchmark('Square root', () {
      for (var i = 0; i < 100; i++)
        for (final n in list!) {
          n.isPrimeSqrt;
        }
    }, iterations: 100);

    benchmark('Square root leap', () {
      for (var i = 0; i < 100; i++)
        for (final n in list!) {
          n.isPrimeSqrtLeap;
        }
    }, iterations: 100);

    benchmark('Squared', () {
      for (var i = 0; i < 100; i++)
        for (final n in list!) {
          n.isPrimeSq;
        }
    }, iterations: 100);

    benchmark('Cached', () {
      for (var i = 0; i < 100; i++)
        for (final n in list!) {
          n.isPrimeCached;
        }
    }, iterations: 100);
  });
}
```
</details> 

Thus, caching primes is slower and not even more performant than any other method.